### PR TITLE
Fix an off by one error

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,7 +67,7 @@ async function work() {
 
   const requests = []
 
-  while (lastProcessedPosition.blockNumber + requests.length < currentBlock) {
+  while (lastProcessedPosition.blockNumber + requests.length <= currentBlock) {
     const blockToDownload = lastProcessedPosition.blockNumber + requests.length
 
     requests.push(fetchBlock(blockToDownload))


### PR DESCRIPTION
The second condition on row 75 would never be met so you would always wait for `SEND_BATCH_SIZE` blocks to be accumulated before flushing them.