### PR TITLE
fix: Increase default export timeout to 30 minutes

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ const CONFIRMATIONS = parseInt(process.env.CONFIRMATIONS || "3")
 const NODE_URL = process.env.NODE_URL || 'http://litecoin.stage.san:30992'
 const RPC_USERNAME = process.env.RPC_USERNAME || 'rpcuser'
 const RPC_PASSWORD = process.env.RPC_PASSWORD || 'rpcpassword'
-const EXPORT_TIMEOUT_MLS = parseInt(process.env.EXPORT_TIMEOUT_MLS || 1000 * 60 * 15)     // 15 minutes
+const EXPORT_TIMEOUT_MLS = parseInt(process.env.EXPORT_TIMEOUT_MLS || 1000 * 60 * 30)     // 30 minutes
 const DOGE = parseInt(process.env.DOGE || "0")
 const MAX_CONCURRENT_REQUESTS = parseInt(process.env.MAX_CONCURRENT_REQUESTS || "10")
 


### PR DESCRIPTION
It often happens in the Bitcoin blockchain that the interval between
two consecutive blocks is much higher than 10 minutes and also higher
than 15. The previous timeout leads to many unnecessary restarts
because a healthcheck fails whenever no new block has appeared.

We increase the default timeout to 30 minutes to reduce the number of
restarts.